### PR TITLE
Display fix

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,4 +42,6 @@ input, h2 span {
 }
 
 #output svg {
+  transform: scale(1.5) translateX(-.5rem);
+  transform-origin: top left;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ function App() {
     document.querySelector('#output').innerText = '';
   };
   const factory = new Factory({
-    renderer: { elementId: "output", maxWidth: 500, height: 400 },
+    renderer: { elementId: "output", width: 500, height: 700 },
   });
   
   const updateSvg = (n) => {
@@ -36,7 +36,7 @@ function App() {
       .System()
       .addStave({
           voices: [
-            score.voice(score.notes(`${note}/h, ${note}/q, ${note}/q`)), 
+            score.voice(score.notes(`C#5/q, ${note}/q, C#5/h`)), 
           ],
       })
       .addClef("treble")

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ function App() {
     clear();
     if (!!n.match(/^[A-Ga-g]{1}[b,#]{0,1}\d{1}$/)) { 
       setNote(n);
-      setDisplayNote((n.replace('b', '♭').replace('#', '♯')));
+      setDisplayNote((n.replace(/(?<=[a-gA-G])b(?=\d{1})/, '♭').replace('#', '♯')));
     }
     document.querySelector('#output svg')?.remove();
   }


### PR DESCRIPTION
<img src="https://github.com/picaq/notation-map/assets/34908590/df2665d7-5b3d-404d-a498-fbfadc2b1431" alt="app screenshot" width="402" align=right>

- increase regex specificity for flat replacement (corrects flat display error. ex: B♭3 displaying as ♭B3)
- increase output size
- adjust staff & note positions